### PR TITLE
clarify docs about NA, NaN, and numeric

### DIFF
--- a/src/library/base/man/NA.Rd
+++ b/src/library/base/man/NA.Rd
@@ -25,7 +25,8 @@
   other atomic vector types which support missing values: all of these
   are \link{reserved} words in the \R language.
 
-  The generic function \code{is.na} indicates which elements are missing.
+  The generic function \code{is.na} indicates which elements are missing
+  (\code{NA}) or  (NA) or \sQuote{Not a Number} (\code{link{NaN}}). 
 
   The generic function \code{is.na<-} sets elements to \code{NA}.
 
@@ -122,8 +123,11 @@ is.na(x) <- value
   on how methods can be tuned to deal with missing values.
 }
 \examples{
-is.na(c(1, NA))        #> FALSE  TRUE
-is.na(paste(c(1, NA))) #> FALSE FALSE
+is.na(c(1, NA, NA_real__, NaN))        #> FALSE  TRUE  TRUE  TRUE
+is.na(paste(c(1, NA, NA_real__, NaN))) #> FALSE FALSE FALSE FALSE
+
+# When NaN should not be considered as missing value
+is.na(c(1, NA, NA_real_, NaN)) & !is.nan(c(1, NA, NA_real_, NaN))
 
 (xx <- c(0:4))
 is.na(xx) <- c(2, 4)

--- a/src/library/base/man/NA.Rd
+++ b/src/library/base/man/NA.Rd
@@ -26,7 +26,7 @@
   are \link{reserved} words in the \R language.
 
   The generic function \code{is.na} indicates which elements are missing
-  (\code{NA}) or  (NA) or \sQuote{Not a Number} (\code{link{NaN}}). 
+  (\code{NA}) or \sQuote{Not a Number} (\code{link{NaN}}). 
 
   The generic function \code{is.na<-} sets elements to \code{NA}.
 
@@ -123,8 +123,8 @@ is.na(x) <- value
   on how methods can be tuned to deal with missing values.
 }
 \examples{
-is.na(c(1, NA, NA_real__, NaN))        #> FALSE  TRUE  TRUE  TRUE
-is.na(paste(c(1, NA, NA_real__, NaN))) #> FALSE FALSE FALSE FALSE
+is.na(c(1, NA, NA_real_, NaN))        #> FALSE  TRUE  TRUE  TRUE
+is.na(paste(c(1, NA, NA_real_, NaN))) #> FALSE FALSE FALSE FALSE
 
 # When NaN should not be considered as missing value
 is.na(c(1, NA, NA_real_, NaN)) & !is.nan(c(1, NA, NA_real_, NaN))

--- a/src/library/base/man/is.finite.Rd
+++ b/src/library/base/man/is.finite.Rd
@@ -19,9 +19,9 @@
 
   \code{Inf} and \code{-Inf} are positive and negative infinity
   whereas \code{NaN} means \sQuote{Not a Number}.  \code{Inf} and
-  \code{NaN} are class of numeric and type of double, and can be
-  used in real and imaginary parts of complex values, but not as
-  values in integer vectors. \code{Inf} and \code{NaN} (as well as
+  \code{NaN} are class of \code{numeric} and type of \code{double},
+  and can be used in real and imaginary parts of complex values, but not
+  as values in integer vectors. \code{Inf} and \code{NaN} (as well as
   \code{\link{NA}}) are
   \link{reserved} words in the \R language.
 }
@@ -86,11 +86,11 @@ NaN
   \code{dimnames} and \code{names} attributes are preserved.
 }
 \seealso{
-  \code{\link{NA}}, \sQuote{\emph{Not Available}} / \sQuote{Missing value} 
-  which is a a logical constant of length 1 which contains a missing
-  value indicator. \code{\link{NA}} can be coerced to numeric as
-  \code{\link{NA_integer_}} and \code{\link{NA_real_}}.
-
+  \code{\link{NA}}, \sQuote{\emph{Not Available}}, which is usually used
+  to denote a missing value. The default mode of \code{NA} is
+  \code{logical}; unlike \code{NaN}, which is always of mode
+  \code{double}.
+  
   \code{\link{Arithmetic}}, \code{\link{double}}, \code{\link{is.na}}.
 }
 \references{

--- a/src/library/base/man/is.finite.Rd
+++ b/src/library/base/man/is.finite.Rd
@@ -18,9 +18,10 @@
   and not missing) or infinite.
 
   \code{Inf} and \code{-Inf} are positive and negative infinity
-  whereas \code{NaN} means \sQuote{Not a Number}.  (These apply to numeric
-  values and real and imaginary parts of complex values but not to
-  values of integer vectors.)  \code{Inf} and \code{NaN} (as well as
+  whereas \code{NaN} means \sQuote{Not a Number}.  \code{Inf} and
+  \code{NaN} are class of numeric and type of double, and can be
+  used in real and imaginary parts of complex values, but not as
+  values in integer vectors. \code{Inf} and \code{NaN} (as well as
   \code{\link{NA}}) are
   \link{reserved} words in the \R language.
 }
@@ -85,11 +86,12 @@ NaN
   \code{dimnames} and \code{names} attributes are preserved.
 }
 \seealso{
-  \code{\link{NA}}, \sQuote{\emph{Not Available}} which is not a number
-  as well, however usually used for missing values and applies to many
-  modes, not just numeric and complex.
+  \code{\link{NA}}, \sQuote{\emph{Not Available}} / \sQuote{Missing value} 
+  which is a a logical constant of length 1 which contains a missing
+  value indicator. \code{\link{NA}} can be coerced to numeric as
+  \code{\link{NA_integer_}} and \code{\link{NA_real_}}.
 
-  \code{\link{Arithmetic}}, \code{\link{double}}.
+  \code{\link{Arithmetic}}, \code{\link{double}}, \code{\link{is.na}}.
 }
 \references{
   The IEC 60559 standard, also known as the
@@ -117,7 +119,7 @@ NaN
 }
 \examples{
 pi / 0 ## = Inf a non-zero number divided by zero creates infinity
-0 / 0  ## =  NaN
+0 / 0  ## =  NaN as defined in IEC 60559 standard
 
 1/0 + 1/0 # Inf
 1/0 - 1/0 # NaN

--- a/src/library/base/man/numeric.Rd
+++ b/src/library/base/man/numeric.Rd
@@ -13,7 +13,10 @@
 \description{
   Creates or coerces objects of type \code{"numeric"}.
   \code{is.numeric} is a more general test of an object being
-  interpretable as numbers.
+  interpretable as numbers. These include special numeric objects
+  \code{\link{Inf}}, \code{\link{NaN}}, \code{\link{NA_integer_}},
+  and \code{\link{NA_real_}}.
+
 }
 \usage{
 numeric(length = 0)
@@ -88,7 +91,8 @@ is.numeric(x)
   coerces to the class.
 }
 \seealso{
-  \code{\link{double}}, \code{\link{integer}}, \code{\link{storage.mode}}.
+  \code{\link{double}}, \code{\link{integer}}, \code{\link{storage.mode}},
+  \code{\link{Inf}}, \code{\link{NaN}}.
 }
 \references{
   Becker, R. A., Chambers, J. M. and Wilks, A. R. (1988)


### PR DESCRIPTION
Originally posted to Mastodon my learning experience about NaN and NA

TIL

doc for`NaN` and `is.nan()` says: `‘NaN’ means ‘Not a Number’` and `NA, ‘_Not Available_’ which is not a number as well...` ->
1. so neither is "a number".

```
> is.nan(c(NaN, NA))
[1]  TRUE FALSE
```
2. So NaN is not "a number" and NA is not "not a number"

doc for `is.numeric()` doesn't mention NA nor NaN, but says `‘is.numeric’ is a more general test of an object being interpretable as numbers.` 
```
> c(is.numeric(NaN), is.numeric(NA))
[1]  TRUE FALSE
```
3. So NaN is "a number", and NA is not "a number"

doc for `is.na()` says `indicates which elements are missing.`
```
> is.na(c(NaN, NA))
[1] TRUE TRUE
```
4. So both are missing.

I feel like the documentation could be a bit more clear on these, and here is a proposal.
